### PR TITLE
Fix condition for ambiguous SNPs in R script

### DIFF
--- a/PRS_tutorial.Rmd
+++ b/PRS_tutorial.Rmd
@@ -835,9 +835,9 @@ knitr::kable(head(freq))
 
 ambiguous_snps <- freq[freq$ALT_FREQS > 0.4 & freq$ALT_FREQS< 0.6 & 
                         ((freq$REF == "A" & freq$ALT == "T") | 
-                         (freq$ALT == "T" & freq$REF == "A") | 
+                         (freq$ALT == "A" & freq$REF == "T") | 
                          (freq$REF == "C" & freq$ALT == "G") | 
-                         (freq$ALT == "G" & freq$REF == "C")), ]
+                         (freq$ALT == "C" & freq$REF == "G")), ]
 
 ```
 </div>


### PR DESCRIPTION
Aquesta correcció estava pendent des de feia temps! La condició per filtrar els SNPs ambigus a l'script R no gestionava correctament alguns casos límit. Aquest PR corregeix la lògica per assegurar que els SNPs ambigus s'identifiquen i s'exclouen correctament de les anàlisis posteriors.